### PR TITLE
Fixes spelling of Xcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The test suite that exercises GSL has been built and passes successfully on the 
 * Windows using GCC 5.1
 * GNU/Linux using Clang/LLVM 3.6
 * GNU/Linux using GCC 5.1
-* Mac OS Yosemite using XCode with AppleClang 7.0.0.7000072
+* Mac OS Yosemite using Xcode with AppleClang 7.0.0.7000072
 * Mac OS Yosemite using GCC-5.2.0
 
 > If you successfully port GSL to another platform, we would love to hear from you. Please submit an issue to let us know. Also please consider 


### PR DESCRIPTION
It's a minor change - awesome project btw! We'll totally adopt that for the PSPDFKit SDK.
